### PR TITLE
Argument unpacking, removed find, more tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,8 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "4.6.6",
-    "codacy/coverage": "dev-master"
+    "phpunit/phpunit": "^5.2",
+    "codacy/coverage": "^1.0"
   },
   "autoload-dev": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,5 +3,9 @@
         <testsuite name="Frogsystem\\Spawn Tests">
             <directory>./test</directory>
         </testsuite>
-    </testsuites>
+    </testsuites><filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">./src</directory>
+    </whitelist>
+</filter>
 </phpunit>

--- a/src/frogsystem/spawn/Container.php
+++ b/src/frogsystem/spawn/Container.php
@@ -209,14 +209,16 @@ class Container implements ContainerInterface, \ArrayAccess
         }
         if (is_array($callable)) {
             $reflection = new \ReflectionMethod($callable[0], $callable[1]);
-            $arguments = $this->inject($reflection, $args);
-            return $reflection->invokeArgs($callable[0], $arguments);
+        }
+        
+        // closures, functions and any other callable
+        if (!isset($reflection)) {
+            $reflection = new \ReflectionFunction($callable);
         }
 
-        // closures, functions and any other callable
-        $reflection = new \ReflectionFunction($callable);
+        // inject arguments
         $arguments = $this->inject($reflection, $args);
-        return $callable(...$arguments); // closures will loose scope if invoked by reflection
+        return $callable(...$arguments);
     }
 
     /**

--- a/src/frogsystem/spawn/Container.php
+++ b/src/frogsystem/spawn/Container.php
@@ -216,7 +216,7 @@ class Container implements ContainerInterface, \ArrayAccess
         // closures, functions and any other callable
         $reflection = new \ReflectionFunction($callable);
         $arguments = $this->inject($reflection, $args);
-        return call_user_func_array($callable, $arguments); // closures will loose scope if invoked by reflection
+        return $callable(...$arguments); // closures will loose scope if invoked by reflection
     }
 
     /**

--- a/src/frogsystem/spawn/Container.php
+++ b/src/frogsystem/spawn/Container.php
@@ -10,7 +10,6 @@ use Interop\Container\ContainerInterface;
  */
 class Container implements ContainerInterface, \ArrayAccess
 {
-
     /**
      * Library of the entries.
      * @var array
@@ -210,7 +209,7 @@ class Container implements ContainerInterface, \ArrayAccess
         if (is_array($callable)) {
             $reflection = new \ReflectionMethod($callable[0], $callable[1]);
         }
-        
+
         // closures, functions and any other callable
         if (!isset($reflection)) {
             $reflection = new \ReflectionFunction($callable);
@@ -266,41 +265,10 @@ class Container implements ContainerInterface, \ArrayAccess
             }
 
             // Couldn't resolve the dependency
-            throw new Exceptions\ContainerException(
-                "Unable to resolve parameter `{$this->getReflectionParameterName($parameter)}` for function/method `{$this->getReflectionFunctionName($reflection)}`."
-            );
+            throw new Exceptions\ParameterResolutionException($reflection, $parameter);
         }
 
         return $arguments;
-    }
-
-    /**
-     * Helper method to get the type of a reflection paramter
-     * @param \ReflectionParameter $parameter
-     * @return NULL|\ReflectionType|string
-     */
-    private function getReflectionParameterName(\ReflectionParameter $parameter)
-    {
-        // parameter is a class
-        if ($class = $parameter->getClass()) {
-            return $class->getName() . ' \$' . $parameter->getName();
-        }
-
-        return $parameter->getName();
-    }
-
-    /**
-     * Helper method to retrieve the name of a ReflectionFunctionAbstract
-     * @param \ReflectionFunctionAbstract $reflection
-     * @return string
-     */
-    private function getReflectionFunctionName(\ReflectionFunctionAbstract $reflection)
-    {
-        // Class method
-        if ($reflection instanceof \ReflectionMethod) {
-            return $reflection->getDeclaringClass()->getName() . '::' . $reflection->getName();
-        }
-        return $reflection->getName();
     }
 
     /**

--- a/src/frogsystem/spawn/Container.php
+++ b/src/frogsystem/spawn/Container.php
@@ -176,13 +176,13 @@ class Container implements ContainerInterface, \ArrayAccess
      * @param $concrete
      * @param array $args
      * @return mixed
-     * @throws Exceptions\ContainerException
+     * @throws Exceptions\InvalidArgumentException
      */
     public function make($concrete, array $args = [])
     {
         // build only from strings
-        if (!is_string($concrete)) {
-            throw new Exceptions\ContainerException("Unable to find concrete {(string) $concrete}");
+        if (!is_object($concrete) && !is_scalar($concrete) && !is_null($concrete)) {
+            throw new Exceptions\InvalidArgumentException();
         }
 
         // get reflection and parameters
@@ -192,23 +192,6 @@ class Container implements ContainerInterface, \ArrayAccess
         // Return new instance
         $arguments = $constructor ? $this->inject($constructor, $args) : [];
         return $reflection->newInstanceArgs($arguments);
-    }
-
-    /**
-     * Find a instance of any abstract in delegate or make a new object from a concrete if possible.
-     * @param string $abstract
-     * @param array $args
-     * @return mixed
-     */
-    public function find($abstract, array $args = [])
-    {
-        // try to get abstract from delegate
-        if ($this->delegate->has($abstract)) {
-            return $this->delegate->get($abstract, $args);
-        }
-
-        // Try to return new instance
-        return $this->make($abstract, $args);
     }
 
     /**

--- a/src/frogsystem/spawn/Exceptions/ContainerException.php
+++ b/src/frogsystem/spawn/Exceptions/ContainerException.php
@@ -4,7 +4,9 @@ namespace Frogsystem\Spawn\Exceptions;
 use Interop\Container\Exception\ContainerException as ContainerExceptionInterface;
 
 /**
+ * Class ContainerException
  * Base interface representing a generic exception in a container.
+ * @package Frogsystem\Spawn\Exceptions
  */
 class ContainerException extends \Exception implements ContainerExceptionInterface
 {

--- a/src/frogsystem/spawn/Exceptions/InvalidArgumentException.php
+++ b/src/frogsystem/spawn/Exceptions/InvalidArgumentException.php
@@ -2,7 +2,7 @@
 namespace Frogsystem\Spawn\Exceptions;
 
 /**
- * No entry was found in the container.
+ * Passed argument is invalid as an abstract
  */
 class InvalidArgumentException extends ContainerException
 {

--- a/src/frogsystem/spawn/Exceptions/InvalidArgumentException.php
+++ b/src/frogsystem/spawn/Exceptions/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Frogsystem\Spawn\Exceptions;
+
+/**
+ * No entry was found in the container.
+ */
+class InvalidArgumentException extends ContainerException
+{
+}

--- a/src/frogsystem/spawn/Exceptions/InvalidArgumentException.php
+++ b/src/frogsystem/spawn/Exceptions/InvalidArgumentException.php
@@ -2,7 +2,9 @@
 namespace Frogsystem\Spawn\Exceptions;
 
 /**
- * Passed argument is invalid as an abstract
+ * Class InvalidArgumentException
+ * Passed argument is invalid as an abstract.
+ * @package Frogsystem\Spawn\Exceptions
  */
 class InvalidArgumentException extends ContainerException
 {

--- a/src/frogsystem/spawn/Exceptions/NotFoundException.php
+++ b/src/frogsystem/spawn/Exceptions/NotFoundException.php
@@ -4,7 +4,9 @@ namespace Frogsystem\Spawn\Exceptions;
 use Interop\Container\Exception\NotFoundException as NotFoundExceptionInterface;
 
 /**
+ * Class NotFoundException
  * No entry was found in the container.
+ * @package Frogsystem\Spawn\Exceptions
  */
 class NotFoundException extends ContainerException implements NotFoundExceptionInterface
 {

--- a/src/frogsystem/spawn/Exceptions/ParameterResolutionException.php
+++ b/src/frogsystem/spawn/Exceptions/ParameterResolutionException.php
@@ -1,0 +1,64 @@
+<?php
+namespace Frogsystem\Spawn\Exceptions;
+
+use Exception;
+
+/**
+ * Class ParameterResolutionException
+ * Exception thrown when a container failed to resolve a parameter for dependency injection.
+ * @package Frogsystem\Spawn\Exceptions
+ */
+class ParameterResolutionException extends ContainerException
+{
+    /**
+     * Construct the exception. Note: The message is NOT binary safe.
+     * @link http://php.net/manual/en/exception.construct.php
+     * @param \ReflectionFunctionAbstract $reflection The reflected method or function.
+     * @param \ReflectionParameter $parameter The paramter failed to resolve.
+     * @param string $message [optional] The Exception message to throw.
+     * @param int $code [optional] The Exception code.
+     * @param Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
+     * @since 5.1.0
+     */
+    public function __construct(\ReflectionFunctionAbstract $reflection, \ReflectionParameter $parameter, $message = null, $code = 0, Exception $previous = null)
+    {
+        // Default Exception message
+        if (is_null($message)) {
+            $message = 'Unable to resolve parameter `%1$s` for function/method `%2$s`.';
+        }
+        parent::__construct(
+            sprintf($message, $this->getReflectionParameterName($parameter), $this->getReflectionFunctionName($reflection)),
+            $code,
+            $previous
+        );
+    }
+
+    /**
+     * Helper method to get the type of a reflection paramter
+     * @param \ReflectionParameter $parameter
+     * @return NULL|\ReflectionType|string
+     */
+    protected function getReflectionParameterName(\ReflectionParameter $parameter)
+    {
+        // parameter is a class
+        if ($class = $parameter->getClass()) {
+            return $class->getName() . ' \$' . $parameter->getName();
+        }
+
+        return $parameter->getName();
+    }
+
+    /**
+     * Helper method to retrieve the name of a ReflectionFunctionAbstract
+     * @param \ReflectionFunctionAbstract $reflection
+     * @return string
+     */
+    protected function getReflectionFunctionName(\ReflectionFunctionAbstract $reflection)
+    {
+        // Class method
+        if ($reflection instanceof \ReflectionMethod) {
+            return $reflection->getDeclaringClass()->getName() . '::' . $reflection->getName();
+        }
+        return $reflection->getName();
+    }
+}

--- a/test/ContainerArrayAccessTest.php
+++ b/test/ContainerArrayAccessTest.php
@@ -1,0 +1,91 @@
+<?php
+namespace Frogsystem\Spawn;
+
+use Interop\Container\Exception\NotFoundException;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class ContainerArrayAccessTest
+ * @package Frogsystem\Spawn
+ */
+class ContainerArrayAccessTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Container
+     */
+    protected $app;
+
+    public function setUp()
+    {
+        $this->app = new Container();
+    }
+
+    public function testOffsetSet()
+    {
+        // Arrange
+        $container = $this->getMock(Container::class, array('set'));
+        $container->expects($this->once())
+            ->method('set');
+
+        // Act
+        $container['something'] = array();
+    }
+
+    public function testOffsetExists()
+    {
+        // Arrange
+        $container = $this->getMock(Container::class, array('has'));
+        $container->expects($this->once())
+            ->method('has')
+            ->with($this->equalTo('something'))
+            ->willReturn(true);
+
+        // Act & Assert
+        $this->assertTrue(isset($container['something']));
+    }
+
+    public function testOffsetUnset()
+    {
+        // Arrange
+        $this->app['something'] = array();
+
+        // Act
+        unset($this->app['something']);
+
+        // Assert
+        $this->assertFalse(isset($container['something']));
+    }
+
+    public function testOffsetGet()
+    {
+        // Arrange and expect
+        $item = new \stdClass();
+        $container = $this->getMock(Container::class, array('has', 'get'));
+        $container->method('has')
+            ->with($this->equalTo(\stdClass::class))
+            ->willReturn(true);
+        $container->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo(\stdClass::class))
+            ->willReturn($item);
+
+        // Act
+        $result = $container[\stdClass::class];
+
+        // Assert
+        $this->assertSame($item, $result);
+    }
+
+    public function testOffsetGetReturnsNull()
+    {
+        // Arrange and expect
+        $container = $this->getMock(Container::class, array('has', 'get'));
+        $container->method('has')
+            ->willReturn(false);
+        $container->expects($this->never())
+            ->method('get');
+
+        // Act & Assert
+        $this->assertNull($container['non_existing']);
+    }
+}

--- a/test/ContainerArrayAccessTest.php
+++ b/test/ContainerArrayAccessTest.php
@@ -53,7 +53,7 @@ class ContainerArrayAccessTest extends PHPUnit_Framework_TestCase
         unset($this->app['something']);
 
         // Assert
-        $this->assertFalse(isset($container['something']));
+        $this->assertFalse(isset($this->app['something']));
     }
 
     public function testOffsetGet()

--- a/test/ContainerInternalsTest.php
+++ b/test/ContainerInternalsTest.php
@@ -1,0 +1,93 @@
+<?php
+namespace Frogsystem\Spawn;
+
+use Interop\Container\Exception\NotFoundException;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Class ContainerInternalsTest
+ * @package Frogsystem\Spawn
+ */
+class ContainerInternalsTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Container
+     */
+    protected $app;
+
+    public function setUp()
+    {
+        $this->app = new Container();
+    }
+
+    public function testInternalsIsset()
+    {
+        // Arrange
+        $item = new \stdClass();
+
+        // Act
+        $this->app->internal = $item;
+
+        // Assert
+        $this->assertTrue(isset($this->app->internal));
+    }
+
+    public function testInternalsSet()
+    {
+        // Arrange
+        $item = new \stdClass();
+
+        // Act
+        $this->app->internal = $item;
+
+        // Assert
+        $this->assertSame($this->app->internal, $item);
+    }
+
+    public function testInternalsUnset()
+    {
+        // Arrange
+        $item = new \stdClass();
+        $this->app->internal = $item;
+
+        // Act
+        unset($this->app->internal);
+
+        // Assert
+        $this->assertFalse(isset($this->app->internal));
+    }
+
+    public function testInternalsGet()
+    {
+        // Arrange and expect
+        $item = new \stdClass();
+        $container = $this->getMock(Container::class, array('has', 'get'));
+        $container->method('has')
+            ->with($this->equalTo(\stdClass::class))
+            ->willReturn(true);
+        $container->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo(\stdClass::class))
+            ->willReturn($item);
+
+        // Act
+        $result = $container[\stdClass::class];
+
+        // Assert
+        $this->assertSame($item, $result);
+    }
+
+    public function testInternalsGetUnset()
+    {
+        // Arrange
+        unset($this->app->internal);
+
+        // Expect
+        $this->expectException(NotFoundException::class);
+
+        // Act
+        $this->app->internal;
+    }
+
+}

--- a/test/ContainerTest.php
+++ b/test/ContainerTest.php
@@ -2,9 +2,11 @@
 namespace Frogsystem\Spawn;
 
 use Frogsystem\Spawn\Exceptions\InvalidArgumentException;
+use Frogsystem\Spawn\Exceptions\ParameterResolutionException;
 use Interop\Container\Exception\ContainerException;
 use Interop\Container\Exception\NotFoundException;
 use PHPUnit_Framework_TestCase;
+use RecursiveIteratorIterator;
 
 /**
  * Class ContainerTest
@@ -186,13 +188,18 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         $this->app->make($object);
     }
 
+    public static function staticInvocationHelper()
+    {
+        return 'staticMethodResult';
+    }
+
     public function testInvokeStaticClassMethod()
     {
         // Act
-        $result = $this->app->invoke('PDO::getAvailableDrivers');
+        $result = $this->app->invoke('\\Frogsystem\\Spawn\\ContainerTest::staticInvocationHelper');
 
         // Assert
-        $this->assertSame(pdo_drivers(), $result);
+        $this->assertSame('staticMethodResult', $result);
     }
 
     public function testInvokeArrayCallable()
@@ -274,5 +281,24 @@ class ContainerTest extends PHPUnit_Framework_TestCase
 
     public function testInvokeResolutionFailed()
     {
+        // Arrange
+        $callable = function ($frog) {
+            return $frog;
+        };
+
+        // Expect
+        $this->expectException(ParameterResolutionException::class);
+
+        // Act
+        $this->app->invoke($callable);
+    }
+
+    public function testInvokeResolutionFailedTypedArgument()
+    {
+        // Expect
+        $this->expectException(ParameterResolutionException::class);
+
+        // Act
+        $this->app->make(RecursiveIteratorIterator::class);
     }
 }


### PR DESCRIPTION
Removed `find` to further simplify code and access
Invoke callables in PHP 5.6 style using argument unpacking
Introduced `InvalidArgumentException`
Added `ParameterResolutionException`
Bumped coverage to 100%
